### PR TITLE
#2 Rules do not load on Windows

### DIFF
--- a/src/assistant/importRules.js
+++ b/src/assistant/importRules.js
@@ -13,7 +13,7 @@
 const FILENAME = 'import-rules.js';
 
 const getRules = async (outputPath) => {
-  const rulesModule = await import(`${process.cwd()}${outputPath}/${FILENAME}`);
+  const rulesModule = await import(`file://${process.cwd()}${outputPath}/${FILENAME}`);
   return rulesModule.default;
 }
 


### PR DESCRIPTION
## Description

See #2  (`import` mistook `c:` as a protocol)

## Related Issue

#2 

## Motivation and Context

Make it possible to use the builder on Windows.

## How Has This Been Tested?

Ran it on Windows

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
