### PR TITLE
Sites 26837 add import assistant documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,39 +86,7 @@ The `import.js` file you provide will be bundled with any locally referenced scr
 
 ### Assistant
 
-Run AI-enabled commands to assist with your import script development.
-
-Add an npm script entry to your Edge Delivery project's `package.json`:
-
-```
-"assistant": "aem-import-helper assistant"
-```
-
-Run the script:
-
-```
-npm run assistant -- start --url https://example.com --outputPath tools/importer
-npm run assistant -- cleanup --url https://example.com --prompt "content to remove"
-npm run assistant -- block --url https://example.com --name "name of the block" --prompt "describe block content on the page"
-npm run assistant -- cells --url https://example.com --name "name of the block" --prompt "describe content that should be added to the block"
-```
-
-#### Commands
-
-- `start`: Start a new import project
-- `cleanup`: Remove content from the page
-- `block`: Define a block on the page
-- `cells`: Add content to a block
-
-#### Options
-
-- `--url`: The URL of the page to analyze
-- `--outputPath`: The directory to save the import scripts
-- `--name`: The name of the block
-- `--prompt`: Descriptive text to help understand the content
-
-#### Authentication
-
+See [Import Assistant](./docs/import-assistant.md) for usage.
 
 
 ## Coming soon

--- a/README.md
+++ b/README.md
@@ -86,9 +86,12 @@ The `import.js` file you provide will be bundled with any locally referenced scr
 
 ### Assistant
 
+Run AI-enabled commands to assist with your import script development.
+
+Add an npm script entry to your Edge Delivery project's `package.json`:
+
+```
+"assistant": "aem-import-helper assistant"
+```
+
 See [Import Assistant](./docs/import-assistant.md) for usage.
-
-
-## Coming soon
-
-- A report detailing the result of the import, including the reason for any failures

--- a/docs/import-assistant.md
+++ b/docs/import-assistant.md
@@ -2,7 +2,7 @@
  
 Run powerful AI-enabled commands to assist with your import script development.
 
-### Options
+### Required Parameters
 
 - `--url`: The URL of the page to analyze
 - `--outputPath`: The directory to save the import scripts

--- a/docs/import-assistant.md
+++ b/docs/import-assistant.md
@@ -1,17 +1,16 @@
  # Import Assistant
-
----
+ 
 Run powerful AI-enabled commands to assist with your import script development.
 
 &nbsp;
-#### Usage
+### Install
 Add an npm script entry to your Edge Delivery project's `package.json`:
 
 ```
 "assistant": "aem-import-helper assistant"
 ```
 
-#### Options
+### Options
 
 - `--url`: The URL of the page to analyze
 - `--outputPath`: The directory to save the import scripts
@@ -22,7 +21,7 @@ Add an npm script entry to your Edge Delivery project's `package.json`:
 &nbsp;
 ## Commands
 
----
+
 ### Start
 
 Start a new import project.

--- a/docs/import-assistant.md
+++ b/docs/import-assistant.md
@@ -1,14 +1,33 @@
  # Import Assistant
 
+---
 Run powerful AI-enabled commands to assist with your import script development.
 
+&nbsp;
+#### Usage
+Add an npm script entry to your Edge Delivery project's `package.json`:
+
+```
+"assistant": "aem-import-helper assistant"
+```
+
+#### Options
+
+- `--url`: The URL of the page to analyze
+- `--outputPath`: The directory to save the import scripts
+- `--name`: The name of the block
+- `--prompt`: Descriptive text to help understand the content
+
+
+&nbsp;
 ## Commands
 
+---
 ### Start
 
 Start a new import project.
 
-#### Example:
+##### Example:
 ```npm run assistant -- start --url https://example.com --outputPath tools/importer```
 
 &nbsp;

--- a/docs/import-assistant.md
+++ b/docs/import-assistant.md
@@ -1,0 +1,46 @@
+ # Import Assistant
+
+Run powerful AI-enabled commands to assist with your import script development.
+
+## Commands
+
+### Start
+
+Start a new import project.
+
+#### Example:
+```npm run assistant -- start --url https://example.com --outputPath tools/importer```
+
+### Cleanup
+
+Add elements that can be removed from the document.
+#### Example:
+
+```npm run assistant --cleanup --url https://example.com --prompt "content to remove" --outputPath tools/importer```
+
+
+### Block
+
+Builds the transformation rules for page blocks.
+#### Example:
+
+```npm run assistant -- block --url https://example.com --name "name of the block" --prompt "describe block content on the page" --outputPath tools/importer```
+
+### Cells
+
+Builds the cell rules for a block.
+
+#### Example:
+```npm run assistant -- cells --url https://example.com --name "name of the block" --prompt "describe content that should be added to the block" --outputPath tools/importer```
+
+
+
+### Page
+
+Generates page transformation scripts.
+
+#### Example:
+
+```npm run assistant -- page --url https://example.com --name "The name of the page transformation" --prompt "Prompt for the page transformation function" --outputPath tools/importer```
+
+

--- a/docs/import-assistant.md
+++ b/docs/import-assistant.md
@@ -11,6 +11,7 @@ Start a new import project.
 #### Example:
 ```npm run assistant -- start --url https://example.com --outputPath tools/importer```
 
+&nbsp;
 ### Cleanup
 
 Add elements that can be removed from the document.
@@ -19,6 +20,7 @@ Add elements that can be removed from the document.
 ```npm run assistant --cleanup --url https://example.com --prompt "content to remove" --outputPath tools/importer```
 
 
+&nbsp;
 ### Block
 
 Builds the transformation rules for page blocks.
@@ -26,6 +28,7 @@ Builds the transformation rules for page blocks.
 
 ```npm run assistant -- block --url https://example.com --name "name of the block" --prompt "describe block content on the page" --outputPath tools/importer```
 
+&nbsp;
 ### Cells
 
 Builds the cell rules for a block.
@@ -34,7 +37,7 @@ Builds the cell rules for a block.
 ```npm run assistant -- cells --url https://example.com --name "name of the block" --prompt "describe content that should be added to the block" --outputPath tools/importer```
 
 
-
+&nbsp;
 ### Page
 
 Generates page transformation scripts.

--- a/docs/import-assistant.md
+++ b/docs/import-assistant.md
@@ -2,25 +2,12 @@
  
 Run powerful AI-enabled commands to assist with your import script development.
 
-&nbsp;
-### Install
-Add an npm script entry to your Edge Delivery project's `package.json`:
-
-```
-"assistant": "aem-import-helper assistant"
-```
-
 ### Options
 
 - `--url`: The URL of the page to analyze
 - `--outputPath`: The directory to save the import scripts
-- `--name`: The name of the block
-- `--prompt`: Descriptive text to help understand the content
 
-
-&nbsp;
 ## Commands
-
 
 ### Start
 
@@ -29,39 +16,52 @@ Start a new import project.
 ##### Example:
 ```npm run assistant -- start --url https://example.com --outputPath tools/importer```
 
-&nbsp;
 ### Cleanup
 
 Add elements that can be removed from the document.
+
+#### Options:
+- `--prompt`: Descriptive text to help AI understand which content to remove.
+
 #### Example:
 
-```npm run assistant --cleanup --url https://example.com --prompt "content to remove" --outputPath tools/importer```
+```npm run assistant -- cleanup --url https://example.com --prompt "All breadcrumbs and login component" --outputPath tools/importer```
 
 
-&nbsp;
 ### Block
 
 Builds the transformation rules for page blocks.
+
+#### Options:
+- `--name`: The name of the block
+- `--prompt`: Descriptive text to help AI understand how to create the block.
+
 #### Example:
 
-```npm run assistant -- block --url https://example.com --name "name of the block" --prompt "describe block content on the page" --outputPath tools/importer```
+```npm run assistant -- block --url https://example.com --name "greenWithImageBlock" --prompt "A green box that contains an image on the left and a bold title" --outputPath tools/importer```
 
-&nbsp;
 ### Cells
 
 Builds the cell rules for a block.
 
+#### Options:
+- `--name`: The name of the block
+- `--prompt`: Descriptive text to help AI understand what content to add to a block.
+
 #### Example:
-```npm run assistant -- cells --url https://example.com --name "name of the block" --prompt "describe content that should be added to the block" --outputPath tools/importer```
+```npm run assistant -- cells --url https://example.com --name "imageAndParagraphBlock" --prompt "The first image element and first paragraph. Place all elements in first cell of a row" --outputPath tools/importer```
 
 
-&nbsp;
 ### Page
 
 Generates page transformation scripts.
 
+#### Options:
+- `--name`: The name of the page transformation
+- `--prompt`: Descriptive text to help AI understand how to transform page content.
+
 #### Example:
 
-```npm run assistant -- page --url https://example.com --name "The name of the page transformation" --prompt "Prompt for the page transformation function" --outputPath tools/importer```
+```npm run assistant -- page --url https://example.com --name "listTransformation" --prompt "Find the first list item element that is within a list. Move the list item outside the list it belongs to" --outputPath tools/importer```
 
 


### PR DESCRIPTION

## Description

Adds a new markdown doc in the import helper that is linked from the README. The doc describes all the available assistant commands in the import helper, describe what each command does, provide examples of prompts.  This doc will at first be parity with the existing assistant docs, but allows room to expand, adding new commands and be more verbose.

## Related Issue

https://jira.corp.adobe.com/browse/SITES-26837

## Motivation and Context

Improved documentation

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
