### PR TITLE
feat: Show UI URL when job was created

### DIFF
--- a/src/import/import-helper.js
+++ b/src/import/import-helper.js
@@ -48,7 +48,7 @@ export async function runImportJobAndPoll( {
   const baseURL = getApiBaseUrl(stage);
 
   // Filter out obviously invalid URLs, and ignore comments.
-  const filteredUrls = urls && Array.isArray(urls) ? urls.filter((url) => url.length > 4 && url[0] !== '#') : [];
+  const filteredUrls = Array.isArray(urls) ? urls.filter((url) => url.length > 4 && url[0] !== '#') : [];
 
   function hasProvidedSharePointUrl() {
     return typeof sharePointUploadUrl === 'string';

--- a/test/import/import-helper.test.js
+++ b/test/import/import-helper.test.js
@@ -88,10 +88,16 @@ describe('Import helper tests', () => {
       const testParams = {
         urls: [],
       };
-      await expect(runImportJobAndPoll(testParams)).to.be.rejectedWith(Error, 'No URLs provided');
+      await expect(runImportJobAndPoll(testParams)).to.be.rejectedWith(Error, 'No valid URLs provided');
 
       testParams.urls = null;
-      await expect(runImportJobAndPoll(testParams)).to.be.rejectedWith(Error, 'No URLs provided');
+      await expect(runImportJobAndPoll(testParams)).to.be.rejectedWith(Error, 'No valid URLs provided');
+
+      testParams.urls = ['# This is a comment.'];
+      await expect(runImportJobAndPoll(testParams)).to.be.rejectedWith(Error, 'No valid URLs provided');
+
+      testParams.urls = {type: 'not a string!'};
+      await expect(runImportJobAndPoll(testParams)).to.be.rejectedWith(Error, 'No valid URLs provided');
     });
 
     it ('should create a new job which completes right away', async () => {


### PR DESCRIPTION
## Description

To help the user avoid losing track of their job (hitting CTRL-C, shutting down computer, etc.) provide the Labs' UI URL when the job has been started.

My URL file had an extra blank line at the end of it, and the response said there was 'an invalid character in the header'.  That didn't seem intuitive and didn't provide a quick solution, so I also added a quick filter for the URLs (length > 4 and ignore comments: lines starting with '#')

## Related Issue

#12  https://github.com/adobe/aem-import-helper/issues/12

## Motivation and Context

See description

## How Has This Been Tested?

Using tests, and manually

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/effaea99-03ab-4d69-a46e-d3cd4516f5e2)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
