### PR TITLE
fix(sites-31153): [Xwalk] Use mime type from content-type header for assets with no extension

### DIFF
--- a/src/aem/cmd-handler.js
+++ b/src/aem/cmd-handler.js
@@ -145,7 +145,7 @@ export const aemHandler = async (args) => {
         ? path.join(process.cwd(), args.output)
         : args.output;
 
-      console.log(chalk.yellow('Downloading origin assets...'));
+      console.log(chalk.yellow(`Downloading origin assets to ${downloadFolder}...`));
       await downloadAssets(assetMapping, downloadFolder);
 
       const assetFolder = path.join(downloadFolder, getDamRootFolder(assetMapping));

--- a/src/aem/download-assets.js
+++ b/src/aem/download-assets.js
@@ -16,15 +16,57 @@ import chalk from 'chalk';
 
 const CONTENT_DAM_PREFIX = '/content/dam';
 
+// Common MIME type to extension mapping
+const MIME_TO_EXTENSION = {
+  // Images
+  'image/jpeg': '.jpg',
+  'image/jpg': '.jpg',
+  'image/png': '.png',
+  'image/gif': '.gif',
+  'image/webp': '.webp',
+  'image/svg+xml': '.svg',
+  'image/tiff': '.tiff',
+  'image/bmp': '.bmp',
+  'image/x-icon': '.ico',
+  'image/vnd.microsoft.icon': '.ico',
+  'image/heic': '.heic',
+  'image/heif': '.heif',
+  'image/avif': '.avif',
+  'image/apng': '.apng',
+  // Documents
+  'application/pdf': '.pdf',
+  'application/msword': '.doc',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': '.docx',
+  'application/vnd.ms-excel': '.xls',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': '.xlsx',
+  'application/vnd.ms-powerpoint': '.ppt',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation': '.pptx',
+};
+
 /**
  * Save the given blob to a file in the download folder.
  * @param {Blob} blob - The blob to save.
  * @param {string} jcrPath - The JCR path of the asset.
  * @param {string} downloadFolder - The folder to download assets to.
+ * @param {string} contentType - The content type from the response headers.
  * @return {Promise<void>} A promise that resolves when the blob is saved to a file.
  */
-async function saveBlobToFile(blob, jcrPath, downloadFolder) {
+async function saveBlobToFile(blob, jcrPath, downloadFolder, contentType) {
   let assetPath = path.join(downloadFolder, jcrPath.replace(CONTENT_DAM_PREFIX, ''));
+
+  let extension = '';
+  
+  if (contentType) {
+    // Extract the main MIME type (remove any parameters like charset)
+    const mainType = contentType.split(';')[0].trim();
+    extension = MIME_TO_EXTENSION[mainType] || '';
+  }
+
+  // If the file doesn't have an extension and we found one from content-type, append it
+  if (extension && !path.extname(assetPath)) {
+    assetPath += extension;
+  }
+
   fs.mkdirSync(path.dirname(assetPath), { recursive: true });
 
   const buffer = Buffer.from(await blob.arrayBuffer());
@@ -36,7 +78,7 @@ async function saveBlobToFile(blob, jcrPath, downloadFolder) {
  * @param {string} url - The URL of the asset to download.
  * @param {number} maxRetries - The maximum number of retries for downloading an asset.
  * @param {number} retryDelay - The delay between retries in milliseconds.
- * @return {Promise<Blob>} A promise that resolves with the downloaded asset.
+ * @return {Promise<{blob: Blob, contentType: string}>} A promise that resolves with the downloaded asset and its content type.
  */
 async function downloadAssetWithRetry(url, maxRetries = 3, retryDelay = 5000) {
   let attempts = 0;
@@ -48,7 +90,9 @@ async function downloadAssetWithRetry(url, maxRetries = 3, retryDelay = 5000) {
         console.info(chalk.yellow(msg));
         throw new Error(msg);
       }
-      return await response.blob();
+      const contentType = response.headers.get('content-type');
+      const blob = await response.blob();
+      return { blob, contentType };
     } catch (error) {
       attempts++;
       if (attempts >= maxRetries) {
@@ -72,11 +116,11 @@ async function downloadAssetWithRetry(url, maxRetries = 3, retryDelay = 5000) {
  * @return {Promise<Array<PromiseSettledResult<string>>>} A promise that resolves when all assets are downloaded.
  * Each promise in the array will resolve with the JCR path of the downloaded asset.
  */
-export async function downloadAssets(assetMapping, downloadFolder, maxRetries = 3,retryDelay = 5000) {
+export async function downloadAssets(assetMapping, downloadFolder, maxRetries = 3, retryDelay = 5000) {
   const downloadPromises = Array.from(assetMapping.entries())
     .map(async ([assetUrl, jcrPath]) => {
-      const blob = await downloadAssetWithRetry(assetUrl, maxRetries, retryDelay);
-      await saveBlobToFile(blob, jcrPath, downloadFolder);
+      const { blob, contentType } = await downloadAssetWithRetry(assetUrl, maxRetries, retryDelay);
+      await saveBlobToFile(blob, jcrPath, downloadFolder, contentType);
       return jcrPath;
     });
 

--- a/test/aem/download-assts.test.js
+++ b/test/aem/download-assts.test.js
@@ -102,4 +102,72 @@ describe('download assets', function () {
     await scope.done();
   });
 
+  it('should add extension based on content-type when file has no extension', async () => {
+    const scope = nock('http://www.aem.com')
+      .get('/asset1')
+      .reply(200, 'image data', {
+        'Content-Type': 'image/jpeg'
+      });
+
+    const mapping = new Map([
+      ['http://www.aem.com/asset1', '/content/dam/xwalk/image1'],
+    ]);
+
+    await downloadAssets(mapping, downloadFolder);
+    expect(fs.existsSync(path.join(downloadFolder, 'xwalk/image1.jpg'))).to.be.true;
+
+    await scope.done();
+  });
+
+  it('should not add extension when file already has one', async () => {
+    const scope = nock('http://www.aem.com')
+      .get('/asset1.png')
+      .reply(200, 'image data', {
+        'Content-Type': 'image/jpeg'
+      });
+
+    const mapping = new Map([
+      ['http://www.aem.com/asset1.png', '/content/dam/xwalk/image1.png'],
+    ]);
+
+    await downloadAssets(mapping, downloadFolder);
+    expect(fs.existsSync(path.join(downloadFolder, 'xwalk/image1.png'))).to.be.true;
+
+    await scope.done();
+  });
+
+  it('should handle unknown content-types gracefully', async () => {
+    const scope = nock('http://www.aem.com')
+      .get('/asset1')
+      .reply(200, 'data', {
+        'Content-Type': 'application/unknown'
+      });
+
+    const mapping = new Map([
+      ['http://www.aem.com/asset1', '/content/dam/xwalk/image1'],
+    ]);
+
+    await downloadAssets(mapping, downloadFolder);
+    expect(fs.existsSync(path.join(downloadFolder, 'xwalk/image1'))).to.be.true;
+
+    await scope.done();
+  });
+
+  it('should handle content-type with parameters', async () => {
+    const scope = nock('http://www.aem.com')
+      .get('/asset1')
+      .reply(200, 'image data', {
+        'Content-Type': 'image/jpeg; charset=utf-8'
+      });
+
+    const mapping = new Map([
+      ['http://www.aem.com/asset1', '/content/dam/xwalk/image1'],
+    ]);
+
+    await downloadAssets(mapping, downloadFolder);
+    expect(fs.existsSync(path.join(downloadFolder, 'xwalk/image1.jpg'))).to.be.true;
+
+    await scope.done();
+  });
+
 });


### PR DESCRIPTION
Currently if assets are missing their extension, UE is not able to resolve them by their type.
In case the extension is missing, we should use the mime type from the content-type header.

[SITES-31153](https://jira.corp.adobe.com/browse/SITES-31153)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
