### PR TITLE
fix: Add browser-like headers to asset downloads to handle browser fingerprinting

### DIFF
--- a/src/utils/download-assets.js
+++ b/src/utils/download-assets.js
@@ -92,11 +92,11 @@ async function downloadAssetWithRetry(url, maxRetries = 3, retryDelay = 5000, he
         'Referer': new URL(url).origin,
         'Sec-Fetch-Site': 'same-origin',
         'Sec-Fetch-Mode': 'no-cors',
-        ...headers
+        ...headers,
       };
       
       const response = await fetch(url, {
-        headers: defaultHeaders
+        headers: defaultHeaders,
       });
       if (!response.ok) {
         const msg = `Failed to fetch ${url}. Status: ${response.status}.`;

--- a/test/utils/download-assets.test.js
+++ b/test/utils/download-assets.test.js
@@ -170,4 +170,32 @@ describe('download assets', function () {
     await scope.done();
   });
 
+  it('should include correct default headers in the request', async () => {
+    const expectedHeaders = {
+      'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+      'Accept': '*/*',
+      'Referer': 'http://www.aem.com',
+      'Sec-Fetch-Site': 'same-origin',
+      'Sec-Fetch-Mode': 'no-cors'
+    };
+
+    const scope = nock('http://www.aem.com')
+      .get('/asset1.jpg')
+      .matchHeader('User-Agent', expectedHeaders['User-Agent'])
+      .matchHeader('Accept', expectedHeaders['Accept'])
+      .matchHeader('Referer', expectedHeaders['Referer'])
+      .matchHeader('Sec-Fetch-Site', expectedHeaders['Sec-Fetch-Site'])
+      .matchHeader('Sec-Fetch-Mode', expectedHeaders['Sec-Fetch-Mode'])
+      .replyWithFile(200, path.resolve(__dirname, '../aem/fixtures/image1.jpeg'));
+
+    const mapping = new Map([
+      ['http://www.aem.com/asset1.jpg', '/content/dam/xwalk/image1.jpg'],
+    ]);
+
+    await downloadAssets(mapping, downloadFolder);
+    expect(fs.existsSync(path.join(downloadFolder, 'xwalk/image1.jpg'))).to.be.true;
+
+    await scope.done();
+  });
+
 });

--- a/test/utils/download-assets.test.js
+++ b/test/utils/download-assets.test.js
@@ -176,7 +176,7 @@ describe('download assets', function () {
       'Accept': '*/*',
       'Referer': 'http://www.aem.com',
       'Sec-Fetch-Site': 'same-origin',
-      'Sec-Fetch-Mode': 'no-cors'
+      'Sec-Fetch-Mode': 'no-cors',
     };
 
     const scope = nock('http://www.aem.com')


### PR DESCRIPTION
Some sites block direct asset downloads with 403 errors but allow browser requests. This PR adds browser-like headers to asset downloads to mimic browser behavior:

- Added Sec-Fetch headers and User-Agent to mimic browser requests
- Set Accept header to '*/*' to handle all asset types
- Maintains dynamic Referer based on asset URL origin