### PR TITLE
fix: support converting webp, avif image types to png

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ npm run da-upload -- \
 **Optional:**
 * _token_: Absolute path to the file containing the IMS token for your DA environment, or the token value.
 * _output_ [default='da-content']: Absolute path to the output folder where the DA content (pages, assets, etc.) will be stored.
+* _images-to-png_ [default=true]: When true, converts downloaded image assets to PNG and updates HTML references to use .png. When false, preserves original image formats and updates references with the original extension. Only use this option if you know your images are supported by DA.
 
 Once the command is executed, the HTML pages and associated assets are uploaded to Author Bus.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/aem-import-helper",
-  "version": "1.0.3",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/aem-import-helper",
-      "version": "1.0.3",
+      "version": "1.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/aem-upload": "2.0.3",
@@ -21,6 +21,7 @@
         "node-fetch": "3.3.2",
         "ora": "8.1.0",
         "puppeteer": "23.1.0",
+        "sharp": "0.33.4",
         "unzipper": "0.12.3",
         "xml2js": "0.6.2",
         "yargs": "17.7.2"
@@ -1432,6 +1433,16 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
+      "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.0.tgz",
@@ -1683,6 +1694,456 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.4.tgz",
+      "integrity": "sha512-p0suNqXufJs9t3RqLBO6vvrgr5OhgbWp76s5gTRvdmxmuv9E1rcaqGUsl3l4mKVmXPkTkTErXediAui4x+8PSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "glibc": ">=2.26",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.2"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.4.tgz",
+      "integrity": "sha512-0l7yRObwtTi82Z6ebVI2PnHT8EB2NxBgpK2MiKJZJ7cz32R4lxd001ecMhzzsZig3Yv9oclvqqdV93jo9hy+Dw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "glibc": ">=2.26",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.2"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-tcK/41Rq8IKlSaKRCCAuuY3lDJjQnYIW1UXU1kxcEKrfL8WR7N6+rzNoOxoQRJWTAECuKwgAHnPvqXGN8XfkHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "macos": ">=11",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-Ofw+7oaWa0HiiMiKWqqaZbaYV3/UGL2wAPeLuJTx+9cXpCRdvQhCLG0IH8YGwM0yGWGLpsF4Su9vM1o6aer+Fw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "macos": ">=10.13",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.2.tgz",
+      "integrity": "sha512-iLWCvrKgeFoglQxdEwzu1eQV04o8YeYGFXtfWU26Zr2wWT3q3MTzC+QTCO3ZQfWd3doKHT4Pm2kRmLbupT+sZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.28",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.2.tgz",
+      "integrity": "sha512-x7kCt3N00ofFmmkkdshwj3vGPCnmiDh7Gwnd4nUwZln2YjqPxV1NlTyZOvoDWdKQVDL911487HOueBvrpflagw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.26",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.2.tgz",
+      "integrity": "sha512-cmhQ1J4qVhfmS6szYW7RT+gLJq9dH2i4maq+qyXayUSn9/3iY2ZeWpbAgSpSVbV2E1JUL2Gg7pwnYQ1h8rQIog==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.28",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.2.tgz",
+      "integrity": "sha512-E441q4Qdb+7yuyiADVi5J+44x8ctlrqn8XgkDTwr4qPJzWkaHwD489iZ4nGDgcuya4iMN3ULV6NwbhRZJ9Z7SQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.26",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.2.tgz",
+      "integrity": "sha512-3CAkndNpYUrlDqkCM5qhksfE+qSIREVpyoeHIU6jd48SJZViAmznoQQLAv4hVXF7xyUB9zf+G++e2v1ABjCbEQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "musl": ">=1.2.2",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.2.tgz",
+      "integrity": "sha512-VI94Q6khIHqHWNOh6LLdm9s2Ry4zdjWJwH56WoiJU7NTeDwyApdZZ8c+SADC8OH98KWNQXnE01UdJ9CSfZvwZw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "musl": ">=1.2.2",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.4.tgz",
+      "integrity": "sha512-RUgBD1c0+gCYZGCCe6mMdTiOFS0Zc/XrN0fYd6hISIKcDUbAW5NtSQW9g/powkrXYm6Vzwd6y+fqmExDuCdHNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.28",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.4.tgz",
+      "integrity": "sha512-2800clwVg1ZQtxwSoTlHvtm9ObgAax7V6MTAB/hDT945Tfyy3hVkmiHpeLPCKYqYR1Gcmv1uDZ3a4OFwkdBL7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.26",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.4.tgz",
+      "integrity": "sha512-h3RAL3siQoyzSoH36tUeS0PDmb5wINKGYzcLB5C6DIiAn2F3udeFAum+gj8IbA/82+8RGCTn7XW8WTFnqag4tQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.31",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.4.tgz",
+      "integrity": "sha512-GoR++s0XW9DGVi8SUGQ/U4AeIzLdNjHka6jidVwapQ/JebGVQIpi52OdyxCNVRE++n1FCLzjDovJNozif7w/Aw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.26",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.4.tgz",
+      "integrity": "sha512-nhr1yC3BlVrKDTl6cO12gTpXMl4ITBUZieehFvMntlCXFzH2bvKG76tBL2Y/OqhupZt81pR7R+Q5YhJxW0rGgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "musl": ">=1.2.2",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.4.tgz",
+      "integrity": "sha512-uCPTku0zwqDmZEOi4ILyGdmW76tH7dm8kKlOIV1XC5cLyJ71ENAAqarOHQh0RLfpIpbV5KOpXzdU6XkJtS0daw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "musl": ">=1.2.2",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.2"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.4.tgz",
+      "integrity": "sha512-Bmmauh4sXUsUqkleQahpdNXKvo+wa1V9KhT2pDA4VJGKwnKMJXiSTGphn0gnJrlooda0QxCtXc6RX1XAU6hMnQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.4.tgz",
+      "integrity": "sha512-99SJ91XzUhYHbx7uhK3+9Lf7+LjwMGQZMDlO/E/YVJ7Nc3lyDFZPGhjwiYdctoH2BOzW9+TnfqcaMKt0jHLdqw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.4.tgz",
+      "integrity": "sha512-3QLocdTRVIrFNye5YocZl+KKpYKP+fksi1QhmOArgx7GyhIbQp/WrJRu176jm8IxromS7RIkzMiMINVdBtC8Aw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@inquirer/checkbox": {
@@ -4288,6 +4749,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4303,6 +4777,16 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -4795,6 +5279,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/devtools-protocol": {
@@ -16583,6 +17076,46 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
+    "node_modules/sharp": {
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.4.tgz",
+      "integrity": "sha512-7i/dt5kGl7qR4gwPRD2biwD2/SvBn3O04J77XKFgL2OnZtQw+AG9wnuS/csmu80nPRHLYE9E41fyEiG8nhH6/Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.0"
+      },
+      "engines": {
+        "libvips": ">=8.15.2",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.4",
+        "@img/sharp-darwin-x64": "0.33.4",
+        "@img/sharp-libvips-darwin-arm64": "1.0.2",
+        "@img/sharp-libvips-darwin-x64": "1.0.2",
+        "@img/sharp-libvips-linux-arm": "1.0.2",
+        "@img/sharp-libvips-linux-arm64": "1.0.2",
+        "@img/sharp-libvips-linux-s390x": "1.0.2",
+        "@img/sharp-libvips-linux-x64": "1.0.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.2",
+        "@img/sharp-linux-arm": "0.33.4",
+        "@img/sharp-linux-arm64": "0.33.4",
+        "@img/sharp-linux-s390x": "0.33.4",
+        "@img/sharp-linux-x64": "0.33.4",
+        "@img/sharp-linuxmusl-arm64": "0.33.4",
+        "@img/sharp-linuxmusl-x64": "0.33.4",
+        "@img/sharp-wasm32": "0.33.4",
+        "@img/sharp-win32-ia32": "0.33.4",
+        "@img/sharp-win32-x64": "0.33.4"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -16738,6 +17271,21 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "license": "MIT"
     },
     "node_modules/sinon": {
       "version": "18.0.1",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "inquirer": "12.2.0",
     "jsdom": "25.0.1",
     "node-fetch": "3.3.2",
+    "sharp": "0.33.4",
     "ora": "8.1.0",
     "puppeteer": "23.1.0",
     "unzipper": "0.12.3",

--- a/src/da/cmd-handler.js
+++ b/src/da/cmd-handler.js
@@ -51,7 +51,7 @@ async function validateAccess(listUrl, token = null) {
     if (token) {
       headers.Authorization = `Bearer ${token}`;
     }
-    
+
     const response = await fetch(listUrl, { method: 'HEAD', headers });
 
     if (response.ok) {
@@ -111,6 +111,11 @@ export const daBuilder = (yargs) => {
       describe: 'Path to a file containing the DA authentication token or the token value',
       type: 'string',
       demandOption: false,
+    })
+    .option('images-to-png', {
+      describe: 'Convert downloaded images to PNG and update references to .png (default: true)',
+      type: 'boolean',
+      default: true,
     });
 }
 
@@ -126,7 +131,7 @@ export const daHandler = async (args) => {
 
   // Handle token (optional)
   let token = args.token;
-  
+
   if (token) {
     // Check if it's a file path (exists as a file)
     if (fs.existsSync(token) && fs.statSync(token).isFile()) {
@@ -136,7 +141,7 @@ export const daHandler = async (args) => {
 
   console.log(chalk.yellow('Validating site access...'));
   const validation = await validateAccess(listUrl, token);
-  
+
   if (!validation.success) {
     if (validation.tokenRequired) {
       console.error(chalk.red('This site requires authentication. Please re-run the command with a valid IMS token.'));
@@ -154,9 +159,9 @@ export const daHandler = async (args) => {
   try {
     // Read and parse the asset list JSON file
     const assetListJson = JSON.parse(fs.readFileSync(args['asset-list'], 'utf-8'));
-    
+
     // Extract the assets array from the JSON structure
-    const assetUrls = new Set(assetListJson.assets || []);    
+    const assetUrls = new Set(assetListJson.assets || []);
     if (assetUrls.size === 0) {
       console.warn(chalk.yellow('No asset urls found in the asset-list file. Expected format: {"assets": ["url1", "url2", ...]}'));
     }
@@ -166,8 +171,17 @@ export const daHandler = async (args) => {
     if (!siteOrigin) {
       console.warn(chalk.yellow('No site origin found in the asset-list file. Relative references will not be updated.'));
     }
-    
-    await processPages(daAdminUrl, daContentUrl, assetUrls, siteOrigin, args['da-folder'], args['output'], token);
+
+    await processPages(
+      daAdminUrl,
+      daContentUrl,
+      assetUrls,
+      siteOrigin,
+      args['da-folder'],
+      args['output'],
+      token,
+      { imagesToPng: args['images-to-png'] },
+    );
 
   } catch (err) {
     console.error(chalk.red('Error during processing:', err));

--- a/src/da/da-helper.js
+++ b/src/da/da-helper.js
@@ -57,15 +57,15 @@ function extractUrlsFromHTML(htmlContent, dependencies = defaultDependencies) {
   const { JSDOM: JSDOMDep } = dependencies;
   const dom = new JSDOMDep(htmlContent);
   const document = dom.window.document;
-  
+
   // Get all href attributes from anchor tags
   const links = document.querySelectorAll('a[href]');
   const linkUrls = Array.from(links).map(link => link.getAttribute('href'));
-  
+
   // Get all src attributes from img tags
   const images = document.querySelectorAll('img[src]');
   const imageUrls = Array.from(images).map(img => img.getAttribute('src'));
-  
+
   // Combine both arrays
   return [...linkUrls, ...imageUrls];
 }
@@ -77,30 +77,39 @@ function extractUrlsFromHTML(htmlContent, dependencies = defaultDependencies) {
  * @param {Set<string>} assetUrls - Set of asset URLs that should be updated
  * @param {string} daContentUrl - The content.da.live URL
  * @param {Object} dependencies - Dependencies for testing (optional)
+ * @param {Object} options - Options for the function
+ * @param {boolean} options.convertImagesToPng - Whether to convert images to PNG
  * @return {string} Updated HTML content with modified hrefs and srcs
  */
-function updateAssetReferencesInHTML(fullShadowPath, htmlContent, assetUrls, daContentUrl, dependencies = defaultDependencies) {
-  const { JSDOM: JSDOMDep } = dependencies;
+function updateAssetReferencesInHTML(fullShadowPath, htmlContent, assetUrls, daContentUrl, dependencies = defaultDependencies, options = {}) {
+  const { JSDOM: JSDOMDep, path: pathDep } = dependencies;
   const dom = new JSDOMDep(htmlContent);
   const document = dom.window.document;
-  
+
   // Map of CSS selectors to their corresponding attribute names
   const selectorAttrMap = new Map([
     ['a[href]', 'href'],
     ['img[src]', 'src'],
     // Add more pairs as needed
   ]);
-  
+
   selectorAttrMap.forEach((attribute, selector) => {
     document.querySelectorAll(selector).forEach(element => {
       const url = element.getAttribute(attribute);
       if (assetUrls.has(url)) {
-        const filename = getFilename(url);
+        let filename = getFilename(url);
+        if (options.convertImagesToPng) {
+          const ext = pathDep.extname(filename).toLowerCase();
+          const imageExts = new Set(['.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg', '.tiff', '.bmp', '.ico', '.heic', '.heif', '.avif', '.apng']);
+          if (imageExts.has(ext)) {
+            filename = `${pathDep.basename(filename, ext)}.png`;
+          }
+        }
         element.setAttribute(attribute, `${daContentUrl}/${fullShadowPath}/${filename}`);
       }
     });
   });
-  
+
   return dom.serialize();
 }
 
@@ -122,9 +131,9 @@ export function updatePageReferencesInHTML(htmlContent, daContentUrl, matchingAs
   if (!siteOrigin) {
     return htmlContent;
   }
-  
+
   let updatedCount = 0;
-  
+
   // Get all anchor tags and update their href attributes
   document.querySelectorAll('a[href]').forEach(element => {
     const url = element.getAttribute('href');
@@ -143,13 +152,13 @@ export function updatePageReferencesInHTML(htmlContent, daContentUrl, matchingAs
     const parsedPath = path.parse(urlObj.pathname);
     const pathWithoutExtension = path.join(parsedPath.dir, parsedPath.name);
     // update the href attribute to point to the DA content location
-    const newUrl = pathWithoutExtension.startsWith('/') 
+    const newUrl = pathWithoutExtension.startsWith('/')
       ? `${daContentUrl}${pathWithoutExtension}`
       : `${daContentUrl}/${pathWithoutExtension}`;
     element.setAttribute('href', newUrl);
     updatedCount++;
   });
-  
+
   if (updatedCount > 0) {
     console.log(chalkDep.cyan(`Updated ${updatedCount} page references to point to DA location`));
   }
@@ -181,21 +190,21 @@ export function createAssetMapping(matchingHrefs, fullShadowPath, dependencies =
  */
 async function downloadPageAssets(matchingHrefs, fullShadowPath, downloadFolder, maxRetries, retryDelay, dependencies = defaultDependencies) {
   const { chalk: chalkDep } = dependencies;
-  
+
   const simplifiedAssetMapping = createAssetMapping(matchingHrefs, fullShadowPath, dependencies);
-  
+
   console.log(chalkDep.blue(`Downloading ${matchingHrefs.length} assets for this page...`));
   const downloadResults = await dependencies.downloadAssets(simplifiedAssetMapping, downloadFolder, maxRetries, retryDelay);
-  
+
   // Count successful downloads
   const successfulDownloads = downloadResults.filter(result => result.status === 'fulfilled').length;
   const failedDownloads = downloadResults.filter(result => result.status === 'rejected').length;
-  
+
   console.log(chalkDep.green(`Successfully downloaded ${successfulDownloads} assets`));
   if (failedDownloads > 0) {
     console.log(chalkDep.red(`Failed to download ${failedDownloads} assets`));
   }
-  
+
   return downloadResults;
 }
 
@@ -211,7 +220,7 @@ async function downloadPageAssets(matchingHrefs, fullShadowPath, downloadFolder,
  */
 async function uploadPageAssets(shadowFolderPath, daAdminUrl, token, uploadOptions, downloadFolder, dependencies = defaultDependencies) {
   const { chalk: chalkDep, uploadFolder: uploadFolderDep } = dependencies;
-  
+
   console.log(chalkDep.yellow(`Uploading assets for page to ${shadowFolderPath}...`));
   try {
     await uploadFolderDep(shadowFolderPath, daAdminUrl, token, {
@@ -237,7 +246,7 @@ async function uploadPageAssets(shadowFolderPath, daAdminUrl, token, uploadOptio
  */
 async function uploadHTMLPage(pagePath, daAdminUrl, token, uploadOptions, htmlFolder, dependencies = defaultDependencies) {
   const { chalk: chalkDep, uploadFile: uploadFileDep } = dependencies;
-  
+
   console.log(chalkDep.yellow(`Uploading updated HTML page: ${pagePath}...`));
   try {
     await uploadFileDep(pagePath, daAdminUrl, token, {
@@ -261,12 +270,12 @@ async function uploadHTMLPage(pagePath, daAdminUrl, token, uploadOptions, htmlFo
  */
 function calculateHtmlPathAndBaseFolder(pagePath, htmlFolder, downloadFolder, dependencies = defaultDependencies) {
   const { path: pathDep } = dependencies;
-  
+
   // Calculate relative path from HTML folder to preserve folder structure
   const htmlRelativePath = pathDep.relative(htmlFolder, pagePath);
   const updatedHtmlPath = pathDep.join(downloadFolder, 'html', htmlRelativePath);
   const htmlBaseFolder = pathDep.join(downloadFolder, 'html');
-  
+
   return {
     updatedHtmlPath,
     htmlBaseFolder,
@@ -281,14 +290,14 @@ function calculateHtmlPathAndBaseFolder(pagePath, htmlFolder, downloadFolder, de
  */
 function saveHtmlToDownloadFolder(htmlContent, updatedHtmlPath, dependencies = defaultDependencies) {
   const { fs: fsDep, chalk: chalkDep, path: pathDep } = dependencies;
-  
+
   const updatedHtmlDir = pathDep.dirname(updatedHtmlPath);
-  
+
   // Create directory structure for HTML
   if (!fsDep.existsSync(updatedHtmlDir)) {
     fsDep.mkdirSync(updatedHtmlDir, { recursive: true });
   }
-  
+
   // Save HTML content to download folder
   fsDep.writeFileSync(updatedHtmlPath, htmlContent, UTF8_ENCODING);
   console.log(chalkDep.green(`Saved page to download folder: ${updatedHtmlPath}`));
@@ -301,13 +310,13 @@ function saveHtmlToDownloadFolder(htmlContent, updatedHtmlPath, dependencies = d
  */
 async function cleanupPageAssets(pathsToClean, dependencies) {
   const { fs: fsDep, chalk: chalkDep } = dependencies;
-  
+
   for (const path of pathsToClean) {
     try {
       // Check if path exists before trying to delete
       if (fsDep.existsSync(path)) {
         const stats = fsDep.statSync(path);
-        
+
         if (stats.isDirectory()) {
           // For directories, use recursive removal
           fsDep.rmSync(path, { recursive: true, force: true });
@@ -383,16 +392,16 @@ async function processSinglePage(pagePath, daFolder, downloadFolder, assetUrls, 
   daContentUrl, token, uploadOptions, dependencies = defaultDependencies) {
   const { fs: fsDep, chalk: chalkDep, path: pathDep } = dependencies;
   const { maxRetries = 3, retryDelay = 5000 } = uploadOptions;
-  
+
   console.log(chalkDep.blue(`\nProcessing page: ${pagePath}`));
-  
+
   try {
     // Read the HTML file
     const htmlContent = fsDep.readFileSync(pagePath, UTF8_ENCODING);
-    
+
     // Extract URLs from the HTML
     const urls = extractUrlsFromHTML(htmlContent, dependencies);
-    
+
     // Find URLs that match asset URLs
     // Decode the URLs and then match
     const matchingAssetUrls = urls.filter(url => {
@@ -405,7 +414,7 @@ async function processSinglePage(pagePath, daFolder, downloadFolder, assetUrls, 
       }
     });
     console.log(chalkDep.yellow(`Found ${matchingAssetUrls.length} asset references.`));
-    
+
     if (matchingAssetUrls.length > 0) {
       // Get fully qualified asset URLs to download from the source
       const fullyQualifiedAssetUrls = getFullyQualifiedAssetUrls(matchingAssetUrls, siteOrigin);
@@ -413,39 +422,61 @@ async function processSinglePage(pagePath, daFolder, downloadFolder, assetUrls, 
       // Extract page name from pagePath to create shadow folder
       const pageName = pathDep.basename(pagePath, pathDep.extname(pagePath));
       const shadowFolder = `.${pageName}`;
-      
+
       // Calculate relative path from HTML folder to preserve folder structure
       const relativePath = pathDep.relative(daFolder, pathDep.dirname(pagePath));
       const fullShadowPath = relativePath ? pathDep.join(relativePath, shadowFolder) : shadowFolder;
       const assetDownloadFolder = pathDep.join(downloadFolder, 'assets');
       const shadowFolderPath = pathDep.join(assetDownloadFolder, fullShadowPath);
-      
+
       // Download assets for this page
-      const downloadResults = await downloadPageAssets(fullyQualifiedAssetUrls, fullShadowPath, assetDownloadFolder, maxRetries, retryDelay, dependencies);
-      
+      const convertImagesToPng = uploadOptions.imagesToPng !== false;
+      const downloadDeps = convertImagesToPng
+        ? {
+          ...dependencies,
+          // Pass option to convert images to PNG during download/save
+          downloadAssets: (mapping, folder, mr, rd) => dependencies.downloadAssets(mapping, folder, mr, rd, {}, { convertImagesToPng: true }),
+        }
+        : dependencies;
+      const downloadResults = await downloadPageAssets(
+        fullyQualifiedAssetUrls,
+        fullShadowPath,
+        assetDownloadFolder,
+        maxRetries,
+        retryDelay,
+        downloadDeps,
+      );
+
       // Upload assets for this page immediately
       await uploadPageAssets(shadowFolderPath, daAdminUrl, token, uploadOptions, assetDownloadFolder, dependencies);
-      
+
       // Make reference updates:
       // 1. Update page references in the HTML content to point to their DA location
       let updatedHtmlContent = updatePageReferencesInHTML(htmlContent, daContentUrl, matchingAssetUrls, siteOrigin, dependencies);
-      // 2. Update the asset references in the HTML content
-      updatedHtmlContent = updateAssetReferencesInHTML(fullShadowPath, updatedHtmlContent, new Set(matchingAssetUrls), daContentUrl, dependencies);
+      // 2. Update the asset references in the HTML content (always rewrite to DA URL; only switch to .png when enabled)
+      updatedHtmlContent = updateAssetReferencesInHTML(
+        fullShadowPath,
+        updatedHtmlContent,
+        new Set(matchingAssetUrls),
+        daContentUrl,
+        dependencies,
+        { convertImagesToPng },
+      );
 
       // Calculate the path for updated HTML content
       const { updatedHtmlPath, htmlBaseFolder } = calculateHtmlPathAndBaseFolder(pagePath, daFolder, downloadFolder, dependencies);
-      
+
       // Save updated HTML content to download folder
       saveHtmlToDownloadFolder(updatedHtmlContent, updatedHtmlPath, dependencies);
-      
+
       // Upload the updated HTML page from the download folder
       try {
         await uploadHTMLPage(updatedHtmlPath, daAdminUrl, token, uploadOptions, htmlBaseFolder, dependencies);
-        
+
         // Clean up downloaded assets and HTML for this page to free disk space
         const assetFolderPath = pathDep.join(assetDownloadFolder, fullShadowPath);
         await cleanupPageAssets([updatedHtmlPath, assetFolderPath], dependencies);
-        
+
         return {
           filePath: pagePath,
           updatedContent: updatedHtmlContent,
@@ -464,16 +495,16 @@ async function processSinglePage(pagePath, daFolder, downloadFolder, assetUrls, 
           uploaded: false,
         };
       }
-      
+
     } else {
       // No matching assets found, save HTML to download folder and upload as-is
       console.log(chalkDep.gray(`No asset references found for page ${pagePath}, saving to download folder and uploading as-is...`));
-      
+
       // Calculate the path for HTML content
       const { updatedHtmlPath, htmlBaseFolder } = calculateHtmlPathAndBaseFolder(pagePath, daFolder, downloadFolder, dependencies);
-      
+
       saveHtmlToDownloadFolder(htmlContent, updatedHtmlPath, dependencies);
-      
+
       try {
         await uploadHTMLPage(updatedHtmlPath, daAdminUrl, token, uploadOptions, htmlBaseFolder, dependencies);
         return {
@@ -495,7 +526,7 @@ async function processSinglePage(pagePath, daFolder, downloadFolder, assetUrls, 
         };
       }
     }
-    
+
   } catch (error) {
     console.error(chalkDep.red(`Error processing page ${pagePath}:`, error.message));
     return {
@@ -583,18 +614,18 @@ export async function processPages(daAdminUrl, daContentUrl, assetUrls, siteOrig
   const getHTMLFilesFn = dependencies.getAllFiles || getAllFiles;
   const htmlPages = getHTMLFilesFn(daFolder, ['.html', '.htm'], dependencies);
   const results = [];
-  
+
   console.log(chalkDep.blue(`Processing ${htmlPages.length} HTML pages sequentially...`));
-  
+
   // Ensure download folder exists
   if (!fsDep.existsSync(downloadFolder)) {
     fsDep.mkdirSync(downloadFolder, { recursive: true });
   }
-  
+
   // Process each page individually
   for (let i = 0; i < htmlPages.length; i++) {
     const pagePath = htmlPages[i];
-    
+
     const result = await processSinglePage(
       pagePath,
       daFolder,
@@ -607,10 +638,10 @@ export async function processPages(daAdminUrl, daContentUrl, assetUrls, siteOrig
       uploadOptions,
       dependencies,
     );
-    
+
     results.push(result);
   }
-  
+
   // process the other (non-html) files
   const otherFilesResults = await processOtherFiles(daFolder, daAdminUrl, token, uploadOptions, dependencies);
   results.push(...otherFilesResults);
@@ -626,6 +657,6 @@ export async function processPages(daAdminUrl, daContentUrl, assetUrls, siteOrig
   console.log(chalkDep.green('\nProcessing complete!'));
   console.log(chalkDep.green(`- Processed ${successfulPages}/${totalFiles} files successfully`));
   console.log(chalkDep.green(`- Downloaded and uploaded ${totalAssets} assets`));
-  
+
   return results;
 }

--- a/test/da/da-helper.test.js
+++ b/test/da/da-helper.test.js
@@ -34,15 +34,15 @@ const mockChalk = {
 
 describe('da-helper.js', () => {
   let sandbox;
-  
+
   beforeEach(() => {
     sandbox = sinon.createSandbox();
   });
-  
+
   afterEach(() => {
     sandbox.restore();
   });
-  
+
   describe('createAssetMapping', () => {
     it('should map asset URLs to shadow folder paths', () => {
       const assetUrls = [
@@ -83,14 +83,14 @@ describe('da-helper.js', () => {
   describe('getFullyQualifiedAssetUrls', () => {
     it('should return original assetUrls when assetUrls is null or undefined', () => {
       const siteOrigin = 'https://example.com';
-      
+
       expect(getFullyQualifiedAssetUrls(null, siteOrigin)).to.be.null;
       expect(getFullyQualifiedAssetUrls(undefined, siteOrigin)).to.be.undefined;
     });
 
     it('should return original assetUrls when siteOrigin is null or undefined', () => {
       const assetUrls = ['image.jpg', '/path/file.png'];
-      
+
       expect(getFullyQualifiedAssetUrls(assetUrls, null)).to.deep.equal(assetUrls);
       expect(getFullyQualifiedAssetUrls(assetUrls, undefined)).to.deep.equal(assetUrls);
       expect(getFullyQualifiedAssetUrls(assetUrls, '')).to.deep.equal(assetUrls);
@@ -99,9 +99,9 @@ describe('da-helper.js', () => {
     it('should convert relative URLs to fully qualified URLs', () => {
       const assetUrls = ['image.jpg', 'folder/file.png', 'assets/logo.svg'];
       const siteOrigin = 'https://example.com';
-      
+
       const result = getFullyQualifiedAssetUrls(assetUrls, siteOrigin);
-      
+
       expect(result).to.be.an('array');
       expect(result).to.have.length(3);
       expect(result[0]).to.equal('https://example.com/image.jpg');
@@ -112,9 +112,9 @@ describe('da-helper.js', () => {
     it('should convert absolute URLs (root relative) to fully qualified URLs', () => {
       const assetUrls = ['/images/image.jpg', '/assets/file.png', '/static/logo.svg'];
       const siteOrigin = 'https://example.com';
-      
+
       const result = getFullyQualifiedAssetUrls(assetUrls, siteOrigin);
-      
+
       expect(result).to.be.an('array');
       expect(result).to.have.length(3);
       expect(result[0]).to.equal('https://example.com/images/image.jpg');
@@ -129,9 +129,9 @@ describe('da-helper.js', () => {
         'https://cdn.example.com/logo.svg',
       ];
       const siteOrigin = 'https://example.com';
-      
+
       const result = getFullyQualifiedAssetUrls(assetUrls, siteOrigin);
-      
+
       expect(result).to.be.an('array');
       expect(result).to.have.length(3);
       expect(result[0]).to.equal('https://example.com/image.jpg');
@@ -145,9 +145,9 @@ describe('da-helper.js', () => {
         'http://localhost:8080/assets/file.png',
       ];
       const siteOrigin = 'https://example.com';
-      
+
       const result = getFullyQualifiedAssetUrls(assetUrls, siteOrigin);
-      
+
       expect(result).to.be.an('array');
       expect(result).to.have.length(2);
       expect(result[0]).to.equal('https://example.com/image.jpg');
@@ -163,9 +163,9 @@ describe('da-helper.js', () => {
         'https://cdn.other.com/external.png',     // external fully qualified
       ];
       const siteOrigin = 'https://example.com';
-      
+
       const result = getFullyQualifiedAssetUrls(assetUrls, siteOrigin);
-      
+
       expect(result).to.be.an('array');
       expect(result).to.have.length(5);
       expect(result[0]).to.equal('https://example.com/image.jpg');
@@ -178,9 +178,9 @@ describe('da-helper.js', () => {
     it('should handle empty array input', () => {
       const assetUrls = [];
       const siteOrigin = 'https://example.com';
-      
+
       const result = getFullyQualifiedAssetUrls(assetUrls, siteOrigin);
-      
+
       expect(result).to.be.an('array');
       expect(result).to.have.length(0);
     });
@@ -188,9 +188,9 @@ describe('da-helper.js', () => {
     it('should handle Set input correctly', () => {
       const assetUrls = new Set(['image.jpg', '/assets/file.png', 'https://example.com/logo.svg']);
       const siteOrigin = 'https://example.com';
-      
+
       const result = getFullyQualifiedAssetUrls(assetUrls, siteOrigin);
-      
+
       expect(result).to.be.an('array');
       expect(result).to.have.length(3);
       expect(result).to.include('https://example.com/image.jpg');
@@ -205,9 +205,9 @@ describe('da-helper.js', () => {
         'https://example.com/logo.svg?cache=bust&v=2',
       ];
       const siteOrigin = 'https://example.com';
-       
+
       const result = getFullyQualifiedAssetUrls(assetUrls, siteOrigin);
-       
+
       expect(result).to.be.an('array');
       expect(result).to.have.length(3);
       expect(result[0]).to.equal('https://example.com/image.jpg?v=123');
@@ -217,17 +217,17 @@ describe('da-helper.js', () => {
 
     it('should handle different site origins correctly', () => {
       const assetUrls = ['logo.png', '/images/banner.jpg'];
-       
+
       // Test with HTTP origin
       let result = getFullyQualifiedAssetUrls(assetUrls, 'http://dev.example.com');
       expect(result[0]).to.equal('http://dev.example.com/logo.png');
       expect(result[1]).to.equal('http://dev.example.com/images/banner.jpg');
-       
+
       // Test with HTTPS origin
       result = getFullyQualifiedAssetUrls(assetUrls, 'https://prod.example.com');
       expect(result[0]).to.equal('https://prod.example.com/logo.png');
       expect(result[1]).to.equal('https://prod.example.com/images/banner.jpg');
-       
+
       // Test with origin having a port
       result = getFullyQualifiedAssetUrls(assetUrls, 'https://staging.example.com:8443');
       expect(result[0]).to.equal('https://staging.example.com:8443/logo.png');
@@ -246,9 +246,9 @@ describe('da-helper.js', () => {
         '/api/files/download/document.pdf',
       ];
       const siteOrigin = 'https://myblog.example.com';
-       
+
       const result = getFullyQualifiedAssetUrls(assetUrls, siteOrigin);
-       
+
       expect(result).to.be.an('array');
       expect(result).to.have.length(7);
       expect(result[0]).to.equal('https://myblog.example.com/dev-image.jpg');
@@ -267,9 +267,9 @@ describe('da-helper.js', () => {
         '/wp-content/uploads/2023/image.jpg?cache=bust&v=2',
       ];
       const siteOrigin = 'https://example.com';
-       
+
       const result = getFullyQualifiedAssetUrls(assetUrls, siteOrigin);
-       
+
       expect(result).to.be.an('array');
       expect(result).to.have.length(3);
       expect(result[0]).to.equal('https://example.com/dev-image.jpg?v=123');
@@ -284,12 +284,12 @@ describe('da-helper.js', () => {
       const daContentUrl = 'https://content.da.live/org/site';
       const matchingAssetUrls = [];
       const siteOrigin = null; // Missing siteOrigin
-      
+
       const result = updatePageReferencesInHTML(htmlContent, daContentUrl, matchingAssetUrls, siteOrigin, {
         JSDOM,
         chalk: mockChalk,
       });
-      
+
       // Should return unchanged HTML content
       expect(result).to.equal(htmlContent);
     });
@@ -299,12 +299,12 @@ describe('da-helper.js', () => {
       const daContentUrl = 'https://content.da.live/org/site';
       const matchingAssetUrls = [];
       const siteOrigin = ''; // Empty siteOrigin
-      
+
       const result = updatePageReferencesInHTML(htmlContent, daContentUrl, matchingAssetUrls, siteOrigin, {
         JSDOM,
         chalk: mockChalk,
       });
-      
+
       // Should return unchanged HTML content
       expect(result).to.equal(htmlContent);
     });
@@ -314,12 +314,12 @@ describe('da-helper.js', () => {
       const daContentUrl = 'https://content.da.live/org/site';
       const matchingAssetUrls = [];
       const siteOrigin = 'https://example.com';
-      
+
       const result = updatePageReferencesInHTML(htmlContent, daContentUrl, matchingAssetUrls, siteOrigin, {
         JSDOM,
         chalk: mockChalk,
       });
-      
+
       // Should update the references
       expect(result).to.include('https://content.da.live/org/site/test-page'); // Extension removed
       expect(result).to.include('https://content.da.live/org/site/page'); // Extension removed
@@ -327,6 +327,56 @@ describe('da-helper.js', () => {
   });
 
   describe('processPages', () => {
+    it('should rewrite asset references to DA but keep original extension when imagesToPng is false', async () => {
+      const createdFolders = new Set(['/html', '/download', '/download/assets', '/html', '/download/assets/.page1']);
+      const mockFs = {
+        existsSync: sinon.stub().callsFake((p) => createdFolders.has(p)),
+        mkdirSync: sinon.stub().callsFake((p) => createdFolders.add(p)),
+        readFileSync: sinon.stub().returns('<html><img src="image.jpg"></html>'),
+        writeFileSync: sinon.stub(),
+        readdirSync: sinon.stub().returns([]),
+        statSync: sinon.stub().returns({ isFile: () => true, isDirectory: () => false }),
+        unlinkSync: sinon.stub(),
+        rmSync: sinon.stub(),
+        rm: sinon.stub().callsArg(2),
+      };
+      const mockPath = path;
+      const mockDownloadAssets = sinon.stub().resolves([{ status: 'fulfilled', value: 'image.jpg' }]);
+      const mockUploadFolder = sinon.stub().resolves({ success: true });
+      const mockUploadFile = sinon.stub().resolves({ success: true });
+      const getHTMLFilesStub = sinon.stub().returns(['/html/page1.html']);
+      const mockDeps = {
+        fs: mockFs,
+        path: mockPath,
+        chalk: mockChalk,
+        JSDOM,
+        downloadAssets: mockDownloadAssets,
+        uploadFolder: mockUploadFolder,
+        uploadFile: mockUploadFile,
+        getAllFiles: sinon.stub().callsFake((dir, exts) => {
+          if (exts && exts.includes('.json')) {
+            return [];
+          }
+          return getHTMLFilesStub();
+        }),
+      };
+      const assetUrls = new Set(['image.jpg']);
+      await processPages(
+        'https://admin.da.live/source/org/site',
+        'https://content.da.live/org/site',
+        assetUrls,
+        'https://example.com',
+        '/html',
+        '/download',
+        'token',
+        { maxRetries: 3, retryDelay: 100, imagesToPng: false },
+        mockDeps,
+      );
+
+      const writtenContent = mockFs.writeFileSync.getCall(0).args[1];
+      expect(writtenContent).to.include('https://content.da.live/org/site/.page1/image.jpg');
+      expect(writtenContent).to.not.include('.png');
+    });
     it('should process pages one by one, downloading and uploading assets immediately', async () => {
       const createdFolders = new Set(['/html', '/download', '/download/assets', '/html', '/download/assets/.page1']);
       const mockFs = {
@@ -378,10 +428,10 @@ describe('da-helper.js', () => {
       expect(getHTMLFilesStub.calledTwice).to.be.true; // Once for HTML files, once for JSON files
       expect(mockUploadFolder.calledOnce).to.be.true; // Once for assets
       expect(mockUploadFile.calledTwice).to.be.true; // Once for HTML, once for JSON
-      
+
       // Check that the HTML content was updated with proper references
       const writtenContent = mockFs.writeFileSync.getCall(0).args[1];
-      expect(writtenContent).to.include('https://content.da.live/org/site/.page1/image.jpg'); // Asset reference updated
+      expect(writtenContent).to.include('https://content.da.live/org/site/.page1/image.png'); // Asset reference updated to PNG
 
       // Final cleanup should be called for the download folder
       expect(mockFs.unlinkSync.calledWith('/download')).to.be.true;
@@ -432,11 +482,11 @@ describe('da-helper.js', () => {
         { maxRetries: 3, retryDelay: 100 },
         mockDeps,
       );
-      
+
       // Check that the HTML content was updated correctly
       expect(mockFs.writeFileSync.calledOnce).to.be.true;
       const writtenContent = mockFs.writeFileSync.getCall(0).args[1];
-      expect(writtenContent).to.include('https://content.da.live/org/site/.page1/image.jpg'); // Asset reference updated
+      expect(writtenContent).to.include('https://content.da.live/org/site/.page1/image.png'); // Asset reference updated to PNG
       expect(writtenContent).to.include('https://content.da.live/org/site/other-page'); // Page reference updated (extension removed)
       expect(writtenContent).to.include('https://content.da.live/org/site/absolute'); // Absolute URL updated (extension removed)
       expect(writtenContent).to.include('https://external.com/some-page.html'); // External URL not updated
@@ -540,7 +590,7 @@ describe('da-helper.js', () => {
         { maxRetries: 3, retryDelay: 100 },
         mockDeps,
       );
-      
+
       expect(mockUploadFolder.calledOnce).to.be.true; // Once for assets
       expect(mockUploadFile.calledTwice).to.be.true; // Once for HTML, once for JSON
 
@@ -792,11 +842,11 @@ describe('da-helper.js', () => {
         }),
       };
       const assetUrls = new Set(['image.jpg']);
-      
+
       // Store original console.warn to restore later
       const originalWarn = console.warn;
       console.warn = mockConsoleWarn;
-      
+
       const results = await processPages(
         'https://admin.da.live/source/org/site',
         'https://content.da.live/org/site',
@@ -808,17 +858,17 @@ describe('da-helper.js', () => {
         { maxRetries: 3, retryDelay: 100 },
         mockDeps,
       );
-      
+
       // Restore console.warn
       console.warn = originalWarn;
-      
+
       expect(results[0].uploaded).to.be.true;
       expect(results[0].downloadedAssets).to.deep.equal(['image.jpg']);
-      
+
       // Check that page references were NOT updated (original HTML should be preserved)
       const writtenContent = mockFs.writeFileSync.getCall(0).args[1];
       expect(writtenContent).to.include('<a href="/other-page.html">Link</a>'); // Original link unchanged
-      expect(writtenContent).to.include('https://content.da.live/org/site/.page1/image.jpg'); // Asset reference still updated
+      expect(writtenContent).to.include('https://content.da.live/org/site/.page1/image.png'); // Asset reference still updated to PNG
     });
   });
 
@@ -847,7 +897,7 @@ describe('da-helper.js', () => {
       };
 
       mockJSDOM = JSDOM;
-      
+
       mockDownloadAssets = sandbox.stub();
       mockUploadFolder = sandbox.stub();
       mockUploadFile = sandbox.stub();
@@ -879,7 +929,7 @@ describe('da-helper.js', () => {
       mockPath.dirname.returns('/download/html');
       mockPath.join.callsFake((...args) => args.join('/'));
       mockPath.parse.withArgs('/').returns({ dir: '', name: '' });
-       
+
       // Mock successful asset operations but failing HTML upload  
       mockDownloadAssets.resolves([{ status: 'fulfilled' }]);
       mockUploadFolder.resolves();
@@ -905,7 +955,7 @@ describe('da-helper.js', () => {
       expect(results[0].error).to.be.a('string');
       expect(results[0].error).to.include('HTML upload failed');
       expect(results[0].uploaded).to.be.false;
-      
+
       // Check JSON result
       expect(results[1].filePath).to.equal('/html/page1.html');
       expect(results[1].uploaded).to.be.false;
@@ -926,7 +976,7 @@ describe('da-helper.js', () => {
       mockPath.basename.withArgs('/html/page2.html').returns('page2.html');
       mockPath.extname.returns('.html');
       mockPath.dirname.returns('/download/html');
-       
+
       // Mock failing HTML upload
       mockUploadFile.rejects(new Error('HTML upload failed for no-asset page'));
 
@@ -949,10 +999,10 @@ describe('da-helper.js', () => {
       expect(results[0].downloadedAssets).to.be.empty;
       expect(results[0].uploaded).to.be.false; // Upload failed
       expect(results[0].error).to.include('HTML upload failed'); // Error should be reported
-       
+
       // Check that error was logged (uploadFile was called and failed)
       expect(mockUploadFile.calledTwice).to.be.true; // Once for HTML, once for JSON
-      
+
       // Check JSON result
       expect(results[1].filePath).to.equal('/html/page2.html');
       expect(results[1].uploaded).to.be.false;
@@ -963,7 +1013,7 @@ describe('da-helper.js', () => {
       mockFs.existsSync.returns(true);
       mockFs.readFileSync.returns('<html><img src="image.jpg"></html>');
       mockGetAllFiles.returns(['/html/page1.html']);
-       
+
       // Mock path operations
       mockPath.relative.withArgs('/html', '/html/page1.html').returns('page1.html');
       mockPath.relative.withArgs('/html', '/html').returns('');
@@ -973,7 +1023,7 @@ describe('da-helper.js', () => {
       mockPath.extname.returns('.html');
       mockPath.dirname.returns('/download/html');
       mockPath.join.callsFake((...args) => args.join('/'));
-       
+
       // Setup file stats mocks - cleanupPageAssets gets called with 2 paths
       // First path (HTML file), second path (asset directory) 
       let statCallCount = 0;
@@ -985,7 +1035,7 @@ describe('da-helper.js', () => {
           return { isDirectory: () => true, isFile: () => false }; // Asset directory
         }
       });
-       
+
       mockDownloadAssets.resolves([{ status: 'fulfilled' }]);
       mockUploadFolder.resolves();
       mockUploadFile.resolves();
@@ -1014,9 +1064,9 @@ describe('da-helper.js', () => {
     it('should handle localhost URL replacement in getFullyQualifiedAssetUrl', () => {
       const localhostUrl = 'http://localhost:3000/image.jpg';
       const siteOrigin = 'https://example.com';
-      
+
       const result = getFullyQualifiedAssetUrls([localhostUrl], siteOrigin);
-      
+
       expect(result).to.have.length(1);
       expect(result[0]).to.equal('https://example.com/image.jpg');
     });
@@ -1024,7 +1074,7 @@ describe('da-helper.js', () => {
     it('should handle URL decoding errors in processSinglePage', async () => {
       // Create an HTML with URLs that will cause decodeURIComponent to fail
       const htmlWithBadUrls = '<html><img src="image%gg.jpg"><img src="valid.jpg"></html>';
-      
+
       mockFs.existsSync.returns(true);
       mockFs.readFileSync.returns(htmlWithBadUrls);
       mockGetAllFiles.returns(['/html/page1.html']);
@@ -1035,7 +1085,7 @@ describe('da-helper.js', () => {
       mockPath.basename.withArgs('page1.html', '.html').returns('page1');
       mockPath.extname.returns('.html');
       mockPath.dirname.returns('/download/html');
-      
+
       mockDownloadAssets.resolves([{ status: 'fulfilled' }]);
       mockUploadFolder.resolves();
       mockUploadFile.resolves();
@@ -1059,7 +1109,7 @@ describe('da-helper.js', () => {
       expect(results).to.have.length(2); // HTML page + JSON page
       expect(results[0].uploaded).to.be.true;
       // Should handle the bad URL gracefully and process the valid one
-      
+
       // Check JSON result
       expect(results[1].filePath).to.equal('/html/page1.html');
       expect(results[1].uploaded).to.be.true;
@@ -1073,9 +1123,9 @@ describe('da-helper.js', () => {
         'https://example.com/valid.jpg',
       ];
       const siteOrigin = 'https://example.com';
-      
+
       const result = getFullyQualifiedAssetUrls(assetUrls, siteOrigin);
-      
+
       expect(result).to.have.length(4);
       expect(result[0]).to.equal('https://example.com/special%20file.jpg'); // localhost replaced
       expect(result[1]).to.equal('https://example.com/relative/path.png'); // relative made absolute
@@ -1086,9 +1136,9 @@ describe('da-helper.js', () => {
     it('should handle empty and null asset URLs', () => {
       const assetUrls = ['', null, undefined, 'valid.jpg'];
       const siteOrigin = 'https://example.com';
-      
+
       const result = getFullyQualifiedAssetUrls(assetUrls, siteOrigin);
-      
+
       expect(result).to.have.length(4);
       expect(result[0]).to.equal(''); // empty string preserved
       expect(result[1]).to.be.null; // null preserved

--- a/test/utils/download-assets.test.js
+++ b/test/utils/download-assets.test.js
@@ -38,8 +38,8 @@ describe('download assets', function () {
       ['http://www.aem.com/asset1.jpg', '/content/dam/xwalk/image1.jpg'],
     ]);
 
-    await downloadAssets(mapping, downloadFolder);
-    expect(fs.existsSync(path.join(downloadFolder, 'xwalk/image1.jpg'))).to.be.true;
+    await downloadAssets(mapping, downloadFolder, 3, 5000, {}, { convertImagesToPng: true });
+    expect(fs.existsSync(path.join(downloadFolder, 'xwalk/image1.png'))).to.be.true;
 
     await scope.done();
   });
@@ -55,8 +55,8 @@ describe('download assets', function () {
       ['http://www.aem.com/asset1.jpg', '/content/dam/xwalk/image1.jpg'],
     ]);
 
-    await downloadAssets(mapping, downloadFolder, 3, 0);
-    expect(fs.existsSync(path.join(downloadFolder, 'xwalk/image1.jpg'))).to.be.true;
+    await downloadAssets(mapping, downloadFolder, 3, 0, {}, { convertImagesToPng: true });
+    expect(fs.existsSync(path.join(downloadFolder, 'xwalk/image1.png'))).to.be.true;
 
     await scope.done();
   });
@@ -77,7 +77,7 @@ describe('download assets', function () {
       ['http://www.aem.com/asset3.jpg', '/content/dam/xwalk/image3.jpg'],
     ]);
 
-    const results = await downloadAssets(mapping, downloadFolder, 1, 0);
+    const results = await downloadAssets(mapping, downloadFolder, 1, 0, {}, { convertImagesToPng: true });
     expect(results.filter((result) => result.status === 'rejected').length).to.equal(2);
     expect(results.filter((result) => result.status === 'fulfilled').length).to.equal(1);
 
@@ -94,7 +94,7 @@ describe('download assets', function () {
     ]);
 
     try {
-      await downloadAssets(mapping, downloadFolder, 1, 0);
+      await downloadAssets(mapping, downloadFolder, 1, 0, {}, { convertImagesToPng: true });
     } catch (error) {
       expect(error.message).to.equal('Failed to fetch http://www.aem.com/asset1.jpg. Status: 404.');
     }
@@ -102,7 +102,7 @@ describe('download assets', function () {
     await scope.done();
   });
 
-  it('should add extension based on content-type when file has no extension', async () => {
+  it('should add extension based on content-type when file has no extension (no conversion)', async () => {
     const scope = nock('http://www.aem.com')
       .get('/asset1')
       .reply(200, 'image data', {
@@ -130,7 +130,7 @@ describe('download assets', function () {
       ['http://www.aem.com/asset1.png', '/content/dam/xwalk/image1.png'],
     ]);
 
-    await downloadAssets(mapping, downloadFolder);
+    await downloadAssets(mapping, downloadFolder, 3, 5000, {}, { convertImagesToPng: true });
     expect(fs.existsSync(path.join(downloadFolder, 'xwalk/image1.png'))).to.be.true;
 
     await scope.done();
@@ -147,13 +147,13 @@ describe('download assets', function () {
       ['http://www.aem.com/asset1', '/content/dam/xwalk/image1'],
     ]);
 
-    await downloadAssets(mapping, downloadFolder);
+    await downloadAssets(mapping, downloadFolder, 3, 5000, {}, { convertImagesToPng: true });
     expect(fs.existsSync(path.join(downloadFolder, 'xwalk/image1'))).to.be.true;
 
     await scope.done();
   });
 
-  it('should handle content-type with parameters', async () => {
+  it('should handle content-type with parameters (no conversion)', async () => {
     const scope = nock('http://www.aem.com')
       .get('/asset1')
       .reply(200, 'image data', {
@@ -192,8 +192,8 @@ describe('download assets', function () {
       ['http://www.aem.com/asset1.jpg', '/content/dam/xwalk/image1.jpg'],
     ]);
 
-    await downloadAssets(mapping, downloadFolder);
-    expect(fs.existsSync(path.join(downloadFolder, 'xwalk/image1.jpg'))).to.be.true;
+    await downloadAssets(mapping, downloadFolder, 3, 5000, {}, { convertImagesToPng: true });
+    expect(fs.existsSync(path.join(downloadFolder, 'xwalk/image1.png'))).to.be.true;
 
     await scope.done();
   });


### PR DESCRIPTION
DA does not support webp and other kinds of image types. The purpose of this ticket is to generate png files based on the unsupported image content.