### PR TITLE
fix: use relative path for Page References in HTML

### DIFF
--- a/src/da/da-helper.js
+++ b/src/da/da-helper.js
@@ -110,13 +110,12 @@ function updateAssetReferencesInHTML(fullShadowPath, htmlContent, assetUrls, daC
 /**
  * Update page references in the HTML content to point to their DA location
  * @param {string} htmlContent - The HTML content to update
- * @param {string} daContentUrl - The content.da.live URL
  * @param {Array<string>} matchingAssetUrls - Array of matching asset URLs
  * @param {string} siteOrigin - The site origin
  * @param {Object} dependencies - Dependencies for testing (optional)
  * @return {string} Updated HTML content
  */
-export function updatePageReferencesInHTML(htmlContent, daContentUrl, matchingAssetUrls, siteOrigin, dependencies = defaultDependencies) {
+export function updatePageReferencesInHTML(htmlContent, matchingAssetUrls, siteOrigin, dependencies = defaultDependencies) {
   const { JSDOM: JSDOMDep, chalk: chalkDep } = dependencies;
   const dom = new JSDOMDep(htmlContent);
   const document = dom.window.document;
@@ -147,8 +146,8 @@ export function updatePageReferencesInHTML(htmlContent, daContentUrl, matchingAs
     const pathWithoutExtension = path.join(parsedPath.dir, parsedPath.name);
     // update the href attribute to point to the DA content location
     const newUrl = pathWithoutExtension.startsWith('/')
-      ? `${daContentUrl}${pathWithoutExtension}`
-      : `${daContentUrl}/${pathWithoutExtension}`;
+      ? `${pathWithoutExtension}`
+      : `/${pathWithoutExtension}`;
     element.setAttribute('href', newUrl);
     updatedCount++;
   });
@@ -447,7 +446,7 @@ async function processSinglePage(pagePath, daFolder, downloadFolder, assetUrls, 
 
       // Make reference updates:
       // 1. Update page references in the HTML content to point to their DA location
-      let updatedHtmlContent = updatePageReferencesInHTML(htmlContent, daContentUrl, matchingAssetUrls, siteOrigin, dependencies);
+      let updatedHtmlContent = updatePageReferencesInHTML(htmlContent, matchingAssetUrls, siteOrigin, dependencies);
       // 2. Update the asset references in the HTML content (always rewrite to DA URL; only switch to .png when enabled)
       updatedHtmlContent = updateAssetReferencesInHTML(
         fullShadowPath,

--- a/test/da/da-helper.test.js
+++ b/test/da/da-helper.test.js
@@ -281,11 +281,10 @@ describe('da-helper.js', () => {
   describe('updatePageReferencesInHTML', () => {
     it('should return unchanged HTML content when siteOrigin is null', () => {
       const htmlContent = '<html><a href="/test-page.html">Test Link</a><a href="https://example.com/page">External Link</a></html>';
-      const daContentUrl = 'https://content.da.live/org/site';
       const matchingAssetUrls = [];
       const siteOrigin = null; // Missing siteOrigin
 
-      const result = updatePageReferencesInHTML(htmlContent, daContentUrl, matchingAssetUrls, siteOrigin, {
+      const result = updatePageReferencesInHTML(htmlContent, matchingAssetUrls, siteOrigin, {
         JSDOM,
         chalk: mockChalk,
       });
@@ -296,11 +295,10 @@ describe('da-helper.js', () => {
 
     it('should return unchanged HTML content when siteOrigin is empty string', () => {
       const htmlContent = '<html><a href="/test-page.html">Test Link</a></html>';
-      const daContentUrl = 'https://content.da.live/org/site';
       const matchingAssetUrls = [];
       const siteOrigin = ''; // Empty siteOrigin
 
-      const result = updatePageReferencesInHTML(htmlContent, daContentUrl, matchingAssetUrls, siteOrigin, {
+      const result = updatePageReferencesInHTML(htmlContent, matchingAssetUrls, siteOrigin, {
         JSDOM,
         chalk: mockChalk,
       });
@@ -311,18 +309,17 @@ describe('da-helper.js', () => {
 
     it('should update page references normally when siteOrigin is provided', () => {
       const htmlContent = '<html><a href="/test-page.html">Test Link</a><a href="https://example.com/page.pdf">Same Origin</a></html>';
-      const daContentUrl = 'https://content.da.live/org/site';
       const matchingAssetUrls = [];
       const siteOrigin = 'https://example.com';
 
-      const result = updatePageReferencesInHTML(htmlContent, daContentUrl, matchingAssetUrls, siteOrigin, {
+      const result = updatePageReferencesInHTML(htmlContent, matchingAssetUrls, siteOrigin, {
         JSDOM,
         chalk: mockChalk,
       });
 
       // Should update the references
-      expect(result).to.include('https://content.da.live/org/site/test-page'); // Extension removed
-      expect(result).to.include('https://content.da.live/org/site/page'); // Extension removed
+      expect(result).to.include('href="/test-page"'); // Extension removed, site-relative
+      expect(result).to.include('href="/page"'); // Extension removed, site-relative
     });
   });
 
@@ -375,7 +372,7 @@ describe('da-helper.js', () => {
       );
 
       const writtenContent = mockFs.writeFileSync.getCall(0).args[1];
-      expect(writtenContent).to.include('https://content.da.live/org/site/.page1/image.jpg');
+      expect(writtenContent).to.include('src="https://content.da.live/org/site/.page1/image.jpg"');
       expect(writtenContent).to.not.include('.png');
     });
     it('should process pages one by one, downloading and uploading assets immediately', async () => {
@@ -433,7 +430,7 @@ describe('da-helper.js', () => {
 
       // Check that the HTML content was updated with proper references
       const writtenContent = mockFs.writeFileSync.getCall(0).args[1];
-      expect(writtenContent).to.include('https://content.da.live/org/site/.page1/image.jpg'); // Asset reference updated with original ext
+      expect(writtenContent).to.include('src="https://content.da.live/org/site/.page1/image.jpg"'); // Asset reference updated with original ext
 
       // Final cleanup should be called for the download folder
       expect(mockFs.unlinkSync.calledWith('/download')).to.be.true;
@@ -489,9 +486,9 @@ describe('da-helper.js', () => {
       // Check that the HTML content was updated correctly
       expect(mockFs.writeFileSync.calledOnce).to.be.true;
       const writtenContent = mockFs.writeFileSync.getCall(0).args[1];
-      expect(writtenContent).to.include('https://content.da.live/org/site/.page1/image.jpg'); // Asset reference updated with original ext
-      expect(writtenContent).to.include('https://content.da.live/org/site/other-page'); // Page reference updated (extension removed)
-      expect(writtenContent).to.include('https://content.da.live/org/site/absolute'); // Absolute URL updated (extension removed)
+      expect(writtenContent).to.include('src="https://content.da.live/org/site/.page1/image.jpg"'); // Asset reference updated with original ext
+      expect(writtenContent).to.include('href="/other-page"'); // Page reference updated (extension removed, site-relative)
+      expect(writtenContent).to.include('href="/absolute"'); // Absolute URL updated (extension removed, site-relative)
       expect(writtenContent).to.include('https://external.com/some-page.html'); // External URL not updated
     });
 
@@ -878,7 +875,7 @@ describe('da-helper.js', () => {
       // Check that page references were NOT updated (original HTML should be preserved)
       const writtenContent = mockFs.writeFileSync.getCall(0).args[1];
       expect(writtenContent).to.include('<a href="/other-page.html">Link</a>'); // Original link unchanged
-      expect(writtenContent).to.include('https://content.da.live/org/site/.page1/image.jpg'); // Asset reference updated with original ext
+      expect(writtenContent).to.include('src="https://content.da.live/org/site/.page1/image.jpg"'); // Asset reference updated with original ext
     });
   });
 


### PR DESCRIPTION
use relative path for Page References in HTML

## Description

Currently the page references use content.da.live which is incorrect, updated it to use relative paths instead.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
