### PR TITLE
fix: [DA] PageReferences In HTML not updated when no assets on page

### DIFF
--- a/src/da/da-helper.js
+++ b/src/da/da-helper.js
@@ -493,19 +493,23 @@ async function processSinglePage(pagePath, daFolder, downloadFolder, assetUrls, 
       }
 
     } else {
-      // No matching assets found, save HTML to download folder and upload as-is
-      console.log(chalkDep.gray(`No asset references found for page ${pagePath}, saving to download folder and uploading as-is...`));
+      // No matching assets found. Still update page references, then save and upload HTML.
+      console.log(chalkDep.gray(`No asset references found for page ${pagePath}. Updating page references and uploading HTML as-is...`));
+
+      // Update page references (asset updates are not needed since there are no matching assets)
+      const updatedHtmlContent = updatePageReferencesInHTML(htmlContent, [], siteOrigin, dependencies);
 
       // Calculate the path for HTML content
       const { updatedHtmlPath, htmlBaseFolder } = calculateHtmlPathAndBaseFolder(pagePath, daFolder, downloadFolder, dependencies);
 
-      saveHtmlToDownloadFolder(htmlContent, updatedHtmlPath, dependencies);
+      // Save updated HTML content to download folder
+      saveHtmlToDownloadFolder(updatedHtmlContent, updatedHtmlPath, dependencies);
 
       try {
         await uploadHTMLPage(updatedHtmlPath, daAdminUrl, token, uploadOptions, htmlBaseFolder, dependencies);
         return {
           filePath: pagePath,
-          updatedContent: htmlContent,
+          updatedContent: updatedHtmlContent,
           downloadedAssets: [],
           downloadResults: [],
           uploaded: true,
@@ -515,7 +519,7 @@ async function processSinglePage(pagePath, daFolder, downloadFolder, assetUrls, 
         return {
           filePath: pagePath,
           error: uploadError.message,
-          updatedContent: htmlContent,
+          updatedContent: updatedHtmlContent,
           downloadedAssets: [],
           downloadResults: [],
           uploaded: false,


### PR DESCRIPTION
fix: [DA] PageReferences In HTML not updated when no assets on page

## Description

<!--- Describe your changes in detail -->

## Related Issue - #47 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
