### PR TITLE
fix: handle extensionless DAM asset reference rewriting in .content.xml using detected file extensions

### DIFF
--- a/src/aem/cmd-handler.js
+++ b/src/aem/cmd-handler.js
@@ -15,7 +15,11 @@ import path from 'path';
 import { cleanup, downloadAssets } from '../utils/download-assets.js';
 import { uploadAssets } from './upload-assets.js';
 import { installPackage } from './package-helper.js';
-import { prepareModifiedPackage, buildExtensionReplacementMap } from './package-modifier.js';
+import {
+  prepareModifiedPackage,
+  buildExtensionReplacementMap,
+  buildDetectedExtensionReplacementMap,
+} from './package-modifier.js';
 import fetch from 'node-fetch';
 import { getDamRootFolder } from './aem-util.js';
 import { printUploadSummary } from './upload-summary.js';
@@ -172,9 +176,16 @@ export const aemHandler = async (args) => {
         console.log(chalk.yellow(`Uploading downloaded assets to ${args.target}...`));
         const { uploadResult, renamedFiles } = await uploadAssets(args.target, token, assetFolder);
 
-        // Build JCR-level replacement map from renamed files so .content.xml paths are updated
+        // Build JCR-level replacement map for extensionless references based on files present
+        // on disk after download/conversion.
+        extensionReplacements = buildDetectedExtensionReplacementMap(assetMapping, assetFolder);
+
+        // Merge in explicit rename-based replacements from addExtensionsToFiles.
         if (renamedFiles && renamedFiles.size > 0) {
-          extensionReplacements = buildExtensionReplacementMap(renamedFiles, assetFolder);
+          const renameBasedReplacements = buildExtensionReplacementMap(renamedFiles, assetFolder);
+          for (const [from, to] of renameBasedReplacements.entries()) {
+            extensionReplacements.set(from, to);
+          }
         }
 
         printUploadSummary(uploadResult);

--- a/src/aem/package-modifier.js
+++ b/src/aem/package-modifier.js
@@ -173,6 +173,57 @@ export function buildExtensionReplacementMap(renamedFiles, assetRootDir) {
 }
 
 /**
+ * Build extension replacements for extensionless JCR paths by checking the downloaded
+ * asset folder for actual files present on disk.
+ *
+ * @param {Map<string,string>} assetMapping - Map of source URL -> JCR path.
+ * @param {string} assetRootDir - Root folder on disk corresponding to /content/dam/<site>.
+ * @return {Map<string,string>} Map of extensionless JCR path -> JCR path with detected extension.
+ */
+export function buildDetectedExtensionReplacementMap(assetMapping, assetRootDir) {
+  const replacements = new Map();
+  if (!assetMapping || assetMapping.size === 0 || !assetRootDir) {
+    return replacements;
+  }
+
+  const damRootSegment = path.basename(assetRootDir);
+  const damRootPrefix = `/content/dam/${damRootSegment}/`;
+
+  for (const jcrPath of assetMapping.values()) {
+    if (path.extname(jcrPath)) {
+      continue;
+    }
+    if (!jcrPath.startsWith(damRootPrefix)) {
+      continue;
+    }
+
+    const relPath = jcrPath.slice(damRootPrefix.length);
+    const relDir = path.dirname(relPath);
+    const baseName = path.basename(relPath);
+    const absDir = relDir === '.' ? assetRootDir : path.join(assetRootDir, relDir);
+
+    if (!fs.existsSync(absDir) || !fs.statSync(absDir).isDirectory()) {
+      continue;
+    }
+
+    const candidates = fs.readdirSync(absDir)
+      .filter((name) => name.startsWith(`${baseName}.`) && name.length > baseName.length + 1)
+      .sort();
+
+    if (candidates.length === 0) {
+      continue;
+    }
+
+    // Prefer .png when present; otherwise choose the first deterministic match.
+    const chosen = candidates.find((name) => name === `${baseName}.png`) || candidates[0];
+    const detectedExt = chosen.slice(baseName.length);
+    replacements.set(jcrPath, `${jcrPath}${detectedExt}`);
+  }
+
+  return replacements;
+}
+
+/**
  * Prepare a modified copy of the AEM content package.
  * - Copies the original zip into a temp folder
  * - Unzips it, updates XML asset references when images are converted to PNG
@@ -215,5 +266,3 @@ export async function prepareModifiedPackage(zipPath, assetMapping, imagesToPng,
   console.info(chalk.yellow('Prepared modified content package with updated asset references.'));
   return { originalZipPath, modifiedZipPath };
 }
-
-

--- a/test/aem/package-modifier.test.js
+++ b/test/aem/package-modifier.test.js
@@ -3,7 +3,14 @@
 
 import { expect } from 'chai';
 import fs from 'fs';
-import { prepareModifiedPackage, buildExtensionReplacementMap } from '../../src/aem/package-modifier.js';
+import os from 'os';
+import path from 'path';
+import archiver from 'archiver';
+import {
+  prepareModifiedPackage,
+  buildExtensionReplacementMap,
+  buildDetectedExtensionReplacementMap,
+} from '../../src/aem/package-modifier.js';
 import unzipper from 'unzipper';
 
 describe('package-modifier', () => {
@@ -36,6 +43,22 @@ describe('package-modifier', () => {
       await directory.extract({ path: zipDir });
     }
   };
+
+  /**
+   * Create a zip archive from a source directory.
+   * @param {string} sourceDir - Directory to archive.
+   * @param {string} outPath - Target zip path.
+   * @returns {Promise<void>}
+   */
+  const zipDirectory = (sourceDir, outPath) => new Promise((resolve, reject) => {
+    const output = fs.createWriteStream(outPath);
+    const archive = archiver('zip', { zlib: { level: 9 } });
+    output.on('close', resolve);
+    archive.on('error', reject);
+    archive.pipe(output);
+    archive.directory(sourceDir, false);
+    archive.finalize();
+  });
 
   /**
    * Make sure that no files have been added or removed when the images have not been 
@@ -71,6 +94,62 @@ describe('package-modifier', () => {
     const modifiedFilesArray = fs.readdirSync(modifiedDestDir, { recursive: true });
 
     expect(originalFilesArray).to.deep.equal(modifiedFilesArray);
+  });
+
+  it('should rewrite extensionless DAM image references in XML to detected uploaded extensions', async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-mod-extless-'));
+    const packageRoot = path.join(tempRoot, 'package');
+    const assetRootDir = path.join(tempRoot, 'assets', 'test-site');
+    const xmlDir = path.join(packageRoot, 'jcr_root', 'content', 'demo', 'en');
+    const imageDir = path.join(assetRootDir, 'is', 'image', 'test-corp');
+    fs.mkdirSync(xmlDir, { recursive: true });
+    fs.mkdirSync(imageDir, { recursive: true });
+
+    const xmlPath = path.join(xmlDir, '.content.xml');
+    const xmlContent = `<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" jcr:primaryType="cq:Page">
+  <jcr:content jcr:primaryType="cq:PageContent"
+    image1="/content/dam/test-site/is/image/test-corp/woman-in-lab-looking-down"
+    image2="/content/dam/test-site/is/image/test-corp/ambily-card-image"
+    image3="/content/dam/test-site/is/image/test-corp/kids-playing-soccer-grass"
+    image4="/content/dam/test-site/is/image/test-corp/wp-card-story-image"
+    image5="/content/dam/test-site/is/image/test-corp/wp-sponsorship-hero"
+    image6="/content/dam/test-site/is/image/test-corp/sitting-in-hammock-by-lake-hero"/>
+</jcr:root>`;
+    fs.writeFileSync(xmlPath, xmlContent, 'utf8');
+    fs.writeFileSync(path.join(imageDir, 'woman-in-lab-looking-down.jpg'), 'x', 'utf8');
+    fs.writeFileSync(path.join(imageDir, 'wp-card-story-image.png'), 'x', 'utf8');
+    fs.writeFileSync(path.join(imageDir, 'wp-sponsorship-hero.png'), 'x', 'utf8');
+    fs.writeFileSync(path.join(imageDir, 'ambily-card-image.jpg'), 'x', 'utf8');
+    fs.writeFileSync(path.join(imageDir, 'kids-playing-soccer-grass.png'), 'x', 'utf8');
+    fs.writeFileSync(path.join(imageDir, 'sitting-in-hammock-by-lake-hero.png'), 'x', 'utf8');
+
+    const inputZip = path.join(tempRoot, 'input.zip');
+    await zipDirectory(packageRoot, inputZip);
+
+    const scene7AssetMap = new Map([
+      ['https://test-corp.scene7.com/is/image/test-corp/woman-in-lab-looking-down?fmt=webp', '/content/dam/test-site/is/image/test-corp/woman-in-lab-looking-down'],
+      ['https://test-corp.scene7.com/is/image/test-corp/wp-card-story-image?$Square$', '/content/dam/test-site/is/image/test-corp/wp-card-story-image'],
+      ['https://test-corp.scene7.com/is/image/test-corp/wp-sponsorship-hero?$Hero$', '/content/dam/test-site/is/image/test-corp/wp-sponsorship-hero'],
+      ['https://test-corp.scene7.com/is/image/test-corp/ambily-card-image?fmt=webp', '/content/dam/test-site/is/image/test-corp/ambily-card-image'],
+      ['https://test-corp.scene7.com/is/image/test-corp/kids-playing-soccer-grass?fmt=webp', '/content/dam/test-site/is/image/test-corp/kids-playing-soccer-grass'],
+      ['https://test-corp.scene7.com/is/image/test-corp/sitting-in-hammock-by-lake-hero?fmt=webp', '/content/dam/test-site/is/image/test-corp/sitting-in-hammock-by-lake-hero'],
+    ]);
+
+    const extensionReplacements = buildDetectedExtensionReplacementMap(scene7AssetMap, assetRootDir);
+    const { modifiedZipPath } = await prepareModifiedPackage(inputZip, scene7AssetMap, false, extensionReplacements);
+
+    const unzipOut = path.join(tempRoot, 'out');
+    await extractZipFiles([[modifiedZipPath, unzipOut]]);
+    const updatedXmlPath = path.join(unzipOut, 'jcr_root', 'content', 'demo', 'en', '.content.xml');
+    const updatedXml = fs.readFileSync(updatedXmlPath, 'utf8');
+
+    expect(updatedXml).to.contain('/content/dam/test-site/is/image/test-corp/woman-in-lab-looking-down.jpg');
+    expect(updatedXml).to.contain('/content/dam/test-site/is/image/test-corp/wp-card-story-image.png');
+    expect(updatedXml).to.contain('/content/dam/test-site/is/image/test-corp/wp-sponsorship-hero.png');
+    expect(updatedXml).to.contain('/content/dam/test-site/is/image/test-corp/ambily-card-image.jpg');
+    expect(updatedXml).to.contain('/content/dam/test-site/is/image/test-corp/kids-playing-soccer-grass.png');
+    expect(updatedXml).to.contain('/content/dam/test-site/is/image/test-corp/sitting-in-hammock-by-lake-hero.png');
   });
 
   describe('buildExtensionReplacementMap', () => {
@@ -126,6 +205,31 @@ describe('package-modifier', () => {
       expect(result.get('/content/dam/mysite/img1')).to.equal('/content/dam/mysite/img1.jpg');
       expect(result.get('/content/dam/mysite/img2')).to.equal('/content/dam/mysite/img2.png');
       expect(result.get('/content/dam/mysite/doc1')).to.equal('/content/dam/mysite/doc1.pdf');
+    });
+  });
+
+  describe('buildDetectedExtensionReplacementMap', () => {
+    it('should detect on-disk extensions for extensionless JCR references', () => {
+      const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-mod-detect-'));
+      const assetRootDir = path.join(tempRoot, 'test-site');
+      const imageDir = path.join(assetRootDir, 'is', 'image', 'test-corp');
+      fs.mkdirSync(imageDir, { recursive: true });
+
+      fs.writeFileSync(path.join(imageDir, 'hero.png'), 'x', 'utf8');
+      fs.writeFileSync(path.join(imageDir, 'card.jpg'), 'x', 'utf8');
+
+      const assetMapForDetection = new Map([
+        ['https://example.com/hero?fmt=webp', '/content/dam/test-site/is/image/test-corp/hero'],
+        ['https://example.com/card', '/content/dam/test-site/is/image/test-corp/card'],
+      ]);
+
+      const result = buildDetectedExtensionReplacementMap(assetMapForDetection, assetRootDir);
+
+      expect(result.size).to.equal(2);
+      expect(result.get('/content/dam/test-site/is/image/test-corp/hero'))
+        .to.equal('/content/dam/test-site/is/image/test-corp/hero.png');
+      expect(result.get('/content/dam/test-site/is/image/test-corp/card'))
+        .to.equal('/content/dam/test-site/is/image/test-corp/card.jpg');
     });
   });
 });


### PR DESCRIPTION
## Description

Fixes missing .content.xml rewrites for extensionless DAM asset paths by deriving `extensionReplacements` from actual uploaded files (plus rename-based replacements), so references like `.../woman-in-lab-looking-down` are updated to the real extension (.jpg/.png). Includes expanded regression tests for Scene7-style mappings and mixed detected extensions.

## Motivation and Context

Customer reporting issue on excat-xwalk env.

## How Has This Been Tested?

- Unit tests 
- Manual E2E

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
