### PR TITLE
fix: Add eslint disable to the bundled import script file

### DIFF
--- a/src/import/bundler.js
+++ b/src/import/bundler.js
@@ -26,6 +26,7 @@ function prepareImportScript(importJsPath) {
       format: 'iife',
       platform: 'browser',
       target: ['es2015'],
+      banner: { js: '/* eslint-disable */' },
     });
 
     return bundle.outputFiles[0].text;

--- a/test/import/bundler.test.js
+++ b/test/import/bundler.test.js
@@ -44,6 +44,7 @@ describe('prepareImportScript tests', () => {
       format: 'iife',
       platform: 'browser',
       target: ['es2015'],
+      banner: { js: '/* eslint-disable */' },
     })).to.be.true;
 
     expect(result).to.equal(bundledCode);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added banner: { js: '/* eslint-disable */' } to the esbuild config in aem-import-helper's src/import/bundler.js (and updated test/import/bundler.test.js) so         
  generated .bundle.js files don't trigger lint errors in downstream EDS projects.

## Related Issue
https://github.com/Adobe-AEM-Foundation/aem-experience-catalyst/issues/845

## Motivation and Context

  Bundles generated by `aem-import-helper bundle` are written to `tools/importer/<name>.bundle.js` in consuming EDS projects, where they get picked up by the project's
   ESLint config and produce hundreds of lint errors during the build (unused vars, non-standard formatting from the minified IIFE, etc.).
                                                                                                                                                                       
  Downstream consumers currently work around this by either adding `tools/importer/**/*.bundle.js` to `.eslintignore` or post-processing the file to prepend a disable 
  banner. Both approaches require every consumer to know about the issue and apply the fix themselves.
                                                                                                                                                                       
  Since the bundler is the single source of these files and esbuild already supports a `banner` option, emitting `/* eslint-disable */` as the first line at generation
   time is the cleanest fix — it makes the artifact safe by default for every consumer with no additional config.

## How Has This Been Tested?
```
  cd /tmp && rm -rf banner-test && mkdir banner-test && cd banner-test                                                                                                 
 ```                        
  ### Minimal valid import script                                                                                                                                        
```  
cat > import-foo.js <<'EOF'
  export default {                                                                                                                                                     
    transform: ({ document }) => ({ path: '/foo', document }),
  }; 
```                                                                                                                                                                  
                                                                                                                                                                       
  ### Point npx at your local checkout so it uses your edits                                                                                                             
  ```
npx --package=<absolute-path-to-aem-import-helper-repo> aem-import-helper bundle --importjs ./import-foo.js                                                                                                                                                           
  head -n 1 import-foo.bundle.js   # should print: /* eslint-disable */                   
```
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
